### PR TITLE
[FEAT] Overthinking judge.

### DIFF
--- a/langProBe/overthinking/__init__.py
+++ b/langProBe/overthinking/__init__.py
@@ -1,0 +1,32 @@
+from langProBe.overthinking.overthinking_program import (
+    OverthinkingGeneratorCriticFuser_20,
+    OverthinkingGeneratorCriticRanker_20,
+    OverthinkingCoT,
+    OverthinkingPredict,
+    OverthinkingGeneratorCriticFuser,
+    OverthinkingGeneratorCriticRanker,
+)
+from .overthinking_data import Overthinking
+from .overthinking_program import *
+
+from langProBe.benchmark import BenchmarkMeta
+
+
+def llm_overthinking_eval(gold, pred, target: str = None):
+    pass
+
+
+benchmark = [
+    BenchmarkMeta(
+        Overthinking,
+        [
+            OverthinkingPredict,
+            OverthinkingCoT,
+            OverthinkingGeneratorCriticFuser,
+            OverthinkingGeneratorCriticRanker,
+            OverthinkingGeneratorCriticFuser_20,
+            OverthinkingGeneratorCriticRanker_20,
+        ],
+        llm_overthinking_eval,
+    )
+]

--- a/langProBe/overthinking/overthinking_data.py
+++ b/langProBe/overthinking/overthinking_data.py
@@ -1,0 +1,8 @@
+from langProBe.benchmark import Benchmark
+from datasets import load_dataset
+import dspy
+
+
+class Overthinking(Benchmark):
+    def init_dataset(self):
+        raw_dataset = load_dataset("AlexCuadron/best_of_o1")

--- a/langProBe/overthinking/overthinking_program.py
+++ b/langProBe/overthinking/overthinking_program.py
@@ -1,0 +1,23 @@
+import dspy
+import langProBe.dspy_program as dspy_program
+
+
+class LLMOverthinkingSignature(dspy.Signature):
+    """
+    Compare two responses to a question, and determine which is better.
+    """
+
+    question = dspy.InputField()
+
+    answer = dspy.OutputField(desc="Is this model overthinking?")
+
+
+OverthinkingPredict = dspy_program.Predict(LLMOverthinkingSignature)
+OverthinkingCoT = dspy_program.CoT(LLMOverthinkingSignature)
+OverthinkingGeneratorCriticFuser = dspy_program.GeneratorCriticFuser(LLMOverthinkingSignature)
+OverthinkingGeneratorCriticFuser_20 = dspy_program.GeneratorCriticFuser(
+    LLMOverthinkingSignature, n=20
+)
+OverthinkingGeneratorCriticRanker_20 = dspy_program.GeneratorCriticRanker(
+    LLMOverthinkingSignature, n=20
+)


### PR DESCRIPTION
Initial implementation of overthinking judge, but needs to be revised. Using the data present [here](https://huggingface.co/datasets/AlexCuadron/best_of_o1). This is the data used for the Pass@k

You can use [this data as your train split](https://huggingface.co/datasets/AlexCuadron/SWE-Bench-Verified-O1-reasoning-high-results). You can use correctness as the gold label (column resolved) and the conversation (column full_conversation_jsonl) as the content for the prompt.

The idea here is that LangProBe could recognise the overthinking patterns present in the conversations then leverage those to predict if the model solved the problem or not.

train set is 500 conv, test set is 100.
